### PR TITLE
Update privacy policy

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -17,17 +17,22 @@ title: Privacy Policy
   <div class="container pt-4 pb-2">
     <p class="text-main mb-3">K-9 Mail is an email client for Android that uses the user's email provider to send and
       retrieve messages. The app requests the following privacy-relevant Android permissions:</p>
+    
     <p class="text-main"><strong>Read/modify your Contacts</strong></p>
     <p class="text-main">The names and email addresses in the user's address book (contacts) are used to provide
       suggestions and auto-complete recipients when composing a message.</p>
-    <p class="text-main"><strong>Read from/write to Storage (Photos/Media/Files)</strong></p>
-    <p class="text-main">The storage area is used to save attachments or export app settings. It can also be used to
-      import app settings or select files to attach to a message the user is composing.</p>
-    <p class="text-main mt-4">For more information on the permissions K-9 Mail requires see: <a
+    <p class="text-main">For more information on the permissions K-9 Mail requires see: <a
         class="text-main underline" href="https://docs.k9mail.app/en/current/setup/permissions/">Permissions</a>.</p>
-    <p class="text-main mb-4">Sensitive user information is only used to perform the basic functionality of the app,
+    
+    <p class="text-main mt-4 mb-4">Sensitive user information is only used to perform the basic functionality of the app,
       sending and receiving email. K-9 Mail does not automatically collect and send data to the developers of the app or
       any third party. Sensitive information is also not included in application logs unless this is enabled by the
       user.</p>
+    <hr>
+    <p class="text-main mt-4">K-9 Mail's use and transfer to any other app of information received from Google APIs
+      will adhere to 
+      <a class="text-main underline" href="https://developers.google.com/terms/api-services-user-data-policy#additional_requirements_for_specific_api_scopes">Google API Services User Data Policy</a>,
+      including the Limited Use requirements.<br>
+      Please note that Google APIs will only be used in case a Google/Gmail account is added to K-9 Mail.</p>
   </div>
 </div>


### PR DESCRIPTION
Add sentence required by Google to be allowed to use the Gmail OAuth scope.

> K-9 Mail's use and transfer to any other app of information received from Google APIs will adhere to [Google API Services User Data Policy](https://developers.google.com/terms/api-services-user-data-policy#additional_requirements_for_specific_api_scopes), including the Limited Use requirements.

Remove the paragraph about the storage permission because the app is no longer using it.