### PR TITLE
Update GitHub workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,15 +7,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '2.6'
+        ruby-version: '3.0'
+        bundler-cache: true
 
     - name: Build with jekyll
-      run: |
-        gem install bundler
-        bundle install --jobs 4 --retry 3
-        bundle exec jekyll build
+      run: bundle exec jekyll build


### PR DESCRIPTION
- `actions/setup-ruby` is deprecated
- Ruby 2.6 was no longer supported
- `actions/checkout` upgraded to v3