### PR TITLE
Update Mastodon link to Thunderbird account

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -57,7 +57,7 @@
                 <h5 class="text-white weight-700 pb-1">Social</h5>
                 <a class="mr-2 text-gray" href="https://github.com/k9mail" target="_blank" rel="noopener"><i
                         class="fab fa-github"></i></a>
-                <a rel="me" class="mr-2 text-gray" href="https://fosstodon.org/@k9mail" target="_blank"
+                <a rel="me" class="mr-2 text-gray" href="https://mastodon.online/@thunderbird" target="_blank"
                     rel="noopener"><i class="fab fa-mastodon"></i></a>
             </div>
         </div>


### PR DESCRIPTION
Since the K9 account is now retired, change the link to Thunderbird's Mastodon account.