### PR TITLE
Download Privacy Policy from Thunderbird

### DIFF
--- a/downloadlegal.py
+++ b/downloadlegal.py
@@ -1,0 +1,32 @@
+import re
+import sys
+import time
+import urllib.request as request
+
+# Download the Thunderbird Privacy Policy and fit it into our layout
+
+THUNDERBIRD_PRIVACY_POLICY_URL = "https://raw.githubusercontent.com/mozilla/legal-docs/main/en/thunderbird_privacy_policy.md"
+
+JEKYLL_HEADER = """
+---
+layout: doc
+title: K-9 Mail Privacy Notice
+---
+""".strip()
+
+
+def main():
+    url = f"{THUNDERBIRD_PRIVACY_POLICY_URL}?token={int(time.time())}"
+    with request.urlopen(url) as response:
+        contents = (
+            response.read()
+            .decode("utf-8")
+            .replace("Thunderbird Privacy Notice", "K-9 Mail Privacy Notice")
+        )
+
+    with open("privacy.md", "w") as file:
+        file.write(f"{JEKYLL_HEADER}\n\n{contents}")
+
+
+if __name__ == "__main__":
+    main()

--- a/privacy.html
+++ b/privacy.html
@@ -1,4 +1,0 @@
----
-title: Privacy Policy
-redirect_to: https://thunderbird.net/privacy/
----

--- a/privacy.md
+++ b/privacy.md
@@ -1,0 +1,106 @@
+---
+layout: doc
+title: K-9 Mail Privacy Notice
+---
+
+# K-9 Mail Privacy Notice
+
+Last updated November 15, 2024
+{: datetime="2024-11-15" }
+
+The Thunderbird Desktop, Thunderbird for Android, and K-9 Mail applications (together, “Thunderbird”) allow users to privately integrate and manage their online communications. K-9 Mail is a variant of Thunderbird for Android. All references to “Thunderbird” or “Thunderbird for Android” apply equally to K-9 Mail.
+
+This Privacy Notice explains what data Thunderbird collects and shares, and why. We also adhere to the [Mozilla Privacy Policy](https://www.mozilla.org/privacy/) for how we receive, handle, and share information.
+
+## Thunderbird Collects Data To:
+
+### Improve Performance, Stability, and Functionality For Our Users
+
+Thunderbird sends telemetry about your interactions with Thunderbird to us. There are two types of telemetry data: interaction data and technical data.
+
+__Interaction data__: Thunderbird receives measurements about how you use Thunderbird and how well it’s working, such as, whether calendars and filters are being used, and how many email accounts a user has.
+
+__Technical data__: Thunderbird also receives environment data from your device, such as, application version, hardware configuration, device operating system, and language preference. When Thunderbird sends technical data to us, your IP address is temporarily collected as part of our server logs.
+
+We use this information to make better decisions on which features should remain included or need to be changed, identify improvements for new features we implement, and find other ways to improve Thunderbird for all our users. Read the telemetry documentation for [Thunderbird Desktop](https://support.mozilla.org/kb/thunderbird-telemetry) or [Thunderbird for Android](https://support.mozilla.org/kb/thunderbird-android-telemetry) to learn how to opt-out of this data collection. Mozilla’s [data dictionary](https://dictionary.telemetry.mozilla.org/) contains information on some of the data points collected.
+
+### Set-Up, Configure, and Process Your Email
+
+Thunderbird collects your email domain and other technical data to set-up and configure your email account. Other information, like your name, your email messages, and your account’s address book are stored and processed locally on your device and never sent to us. Learn more [here](https://support.mozilla.org/kb/automatic-account-configuration).
+
+__Email domain__: Thunderbird receives your email address domain. Your full email address is never processed or stored on our servers (unless you choose to share it when you send a crash report).
+
+__Sending Email__: When using Thunderbird to send an email, you can choose recipients from your contacts. You may optionally attach data such as photos, videos, and audio files to your message. This data is exchanged via your email server between you and the recipient of your email and is never shared with us.
+
+__Technical data__: Thunderbird also receives information about the application’s version and device operating system. When Thunderbird sends technical data to us, your IP address is temporarily collected as part of our server logs.
+
+### Set Up and Configure Your Calendar (Desktop Only)
+
+Thunderbird collects the domain for your email/calendar, as well as technical data to set up and configure your calendar. Other information, like your name, your calendar events, and event attendees are stored and processed locally on your computer and never sent to us. If you are using a remote calendar such as Google, Microsoft, or Apple, calendar content is solely shared with the respective calendar provider and anyone you specifically choose to send appointments to. Calendar contents and personal data are used only to display and enable you to use your calendar in Thunderbird.
+
+### Set Up and Schedule Calendar Appointments with Thunderbird Appointment
+
+With Thunderbird Appointment, you can allow others to schedule appointments on your calendar.
+
+You can connect your Google, Microsoft, or Apple calendar to Thunderbird Appointment to assist with scheduling.
+
+If you choose to connect your Apple Calendar, Microsoft 365, or Google Calendar to Thunderbird Appointment, we will receive basic information about your calendar invites such as the title, date, stated location, the name and emails of the attendees, and any text in the appointment to display them within Thunderbird Appointment and allow you to invite others to schedule time in your calendar. We will receive technical and interaction data about your interactions with this feature such as how many events you create, whether you have connected to a Google, Microsoft, or Apple account.
+
+We will only use your data to provide and improve the Thunderbird Appointment service.
+
+### Review Crash Reports
+
+#### Thunderbird Desktop
+
+If Thunderbird crashes, we will ask you to share a report with more detailed information about the crash, but you always have the choice to decline. Thunderbird uses the information in the crash report to diagnose and correct the problem that caused the crash.
+
+__Sensitive data__: Crash reports include a “dump file” of Thunderbird’s memory contents at the time of the crash, which may contain data that identifies you or is otherwise sensitive to you.
+
+__Webpage data__: Crash reports include any active URLs at time of crash.
+
+__Add-on data__: Crash reports include a list of all add-ons that you were using at the time of the crash, and the time since: the start-up of the program, the last crash, and the last install.
+
+__Technical data__: Crash reports include data on why Thunderbird crashed and the state of device memory and execution during the crash. When Thunderbird sends technical data to us, your IP address is temporarily collected as part of our server logs.
+
+__Email address__: If you choose, crash reports include your email address.
+
+Read the full documentation [here](https://support.mozilla.org/kb/mozilla-crash-reporter-tb).
+
+#### Thunderbird for Android
+
+Google collects crash reports for all Android apps installed via the Play Store. These reports are accessible to us, together with other analytics automatically collected by Google.
+
+### Improve Security for Our Users Everywhere
+
+__Technical data for updates__: To ensure you have the most up-to-date version of the product, Thunderbird Desktop checks for updates by periodically connecting to Thunderbird’s servers. Your application version, language, and device operating system are used to apply the correct updates. [Learn more](https://support.mozilla.org/kb/thunderbird-makes-unrequested-connections#w_auto-update-checking).
+
+__Technical data for add-ons blocklist__: To help to protect you from any malicious add-ons, Thunderbird Desktop periodically checks for blocklisted add-ons. Your Thunderbird version and language, device operating system, and list of installed add-ons are needed to apply and update the add-ons blocklist. [Learn more](https://support.mozilla.org/kb/thunderbird-makes-unrequested-connections#w_extension-blocklist-updating).
+
+### Install and Update Add-Ons (Desktop Only)
+
+You can install add-ons for Thunderbird Desktop from addons.thunderbird.net or from the Thunderbird Add-ons Manager, which is accessible by clicking on Tools \> Add-ons. To keep your installed add-ons up to date—like add-on descriptions, download counts, and ratings—the Thunderbird application periodically connects to our servers to install any updates.
+
+__Search queries__: If you enter keywords into the search field for the Add-ons Manager, those keywords will be sent to Thunderbird to perform the search.
+
+__Interaction data__: We receive aggregate data about visits to the Thunderbird website and the Add-ons Manager in Thunderbird, as well as interactions with content on those pages. Read about data practices on [Mozilla websites](https://www.mozilla.org/privacy/websites/).
+
+__Technical data for updates__: Thunderbird periodically connects to our server to install updates to add-ons. Your installed add-ons, application version, language, and device operating system are used to apply the correct updates. When Thunderbird sends technical data to us, your IP address is temporarily collected as part of our server logs.
+
+## Use of OAuth Information
+
+OAuth is a secure authorization protocol that allows third-party applications to access resources without sharing login credentials. Thunderbird uses OAuth to connect with certain email or calendar providers that mandate or prefer its use, such as Google, Yahoo and Microsoft.
+
+When using OAuth to authorize access to your email or calendars, all data is strictly exchanged over an encrypted connection between the email client application and the OAuth service. Mozilla does not collect, access, or store any sensitive information exchanged during this process.
+
+On your device, login credentials are not retained; instead, they are exchanged for OAuth tokens. These tokens, along with your email and calendar data, are stored within the application sandbox (on Android) or confined within your user profile (on Desktop). When you remove an account, all associated content and tokens will be deleted from your device. On Desktop, the tokens may be retained for a longer period of time in case you have multiple accounts, but can be removed separately in the password manager.
+
+## Thunderbird May Disclose Information To:
+
+__Mozilla Affiliates__: Thunderbird is a project of MZLA Technologies Corporation, a subsidiary of Mozilla Foundation and an affiliate of Mozilla Corporation, and as such, shares some of the same infrastructure. This means that, from time to time, your data (e.g., crash reports, and technical and interaction data) may be disclosed to Mozilla Corporation and Mozilla Foundation. If so, it will be maintained in accordance with the commitments we make in this Privacy Notice.
+
+__DNS servers, Standard Autoconfiguration URIs, and Mozilla's Configuration Database__: To simplify the email set-up process, Thunderbird tries to determine the correct settings for your account by contacting Mozilla’s configuration database as well as external servers. These include DNS servers and standard autoconfiguration URIs. During this process, your email domain may be sent to Mozilla's configuration database, and your email address may be disclosed to your network administrators.
+
+__Amazon Web Services__: Thunderbird uses Amazon Web Services (AWS) to host its servers and as a content delivery network. Your device’s IP address is collected as part of AWS’s server logs.
+
+__Email address providers (Desktop Only Legacy)__: Prior to version 128, Thunderbird partnered with Gandi.net and Mailfence to allow you to create a new email address through Thunderbird. If you choose to use this feature, your email address search terms are sent to Gandi.net and Mailfence to return available addresses. In addition, your country location is also shared to provide the correct prices. You can learn more about [Gandi.net’s](https://contract.gandi.net/v5/contracts/14420/Privacy_Policy_US_2.0_en.pdf) and [Mailfence’s](https://mailfence.com/en/privacy.jsp) data practices by reading their privacy notices.
+


### PR DESCRIPTION
Google's OAuth requires the privacy policy to be hosted on the actual domain, redirects are not possible. With this PR we use the same approach as on thunderbird.net, download from mozilla legal docs and then import it.