### PR TITLE
Change markup of link to privacy policy

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -64,8 +64,7 @@
         <div class="d-block d-lg-flex justify-content-between pt-0 pb-3">
             <div class="small mb-2 mb-lg-0">
                 <p class="top-border mb-1"></p><span class="copyright">&copy; {{ 'now' | date: "%Y" }} K-9
-                    Mail</span><span class="copyright mx-2">|</span><span class="copyright"><a
-                        class="copyright underline-hover" href="/privacy">Privacy Policy</a></span>
+                    Mail</span><span class="copyright mx-2">|</span><span class="copyright"><a href="/privacy" class="copyright underline-hover">Privacy Policy</a></span>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Google's OAuth verification seems to use tooling that can't find our privacy policy. This is an attempt at getting the tool to recognize the link to the privacy policy.