### PR TITLE
Switch "push info" redirect to support.mozilla.org

### DIFF
--- a/go/push-info.md
+++ b/go/push-info.md
@@ -1,4 +1,4 @@
 ---
 title: Push Info
-redirect_to: https://forum.k9mail.app/t/how-to-configure-push/1102
+redirect_to: https://support.mozilla.org/kb/configure-push-email-thunderbird-android
 ---


### PR DESCRIPTION
The short link `https://k9mail.app/go/push-info` is currently used in K-9 Mail and Thunderbird for Android.

The push feature is now documented on SUMO (support.mozilla.org).

I unlisted the forum post so users don't see it in the FAQ section anymore. However, direct links still work. I've also added a note to the content to redirect users to the SUMO page.